### PR TITLE
Restore auth helpers and database tables after merge regressions

### DIFF
--- a/src/app/api/check-ins/route.ts
+++ b/src/app/api/check-ins/route.ts
@@ -31,7 +31,7 @@ function validatePayload(body: unknown) {
 }
 
 export async function POST(request: NextRequest) {
-  const user = getUserFromRequest(request);
+  const user = await getUserFromRequest(request);
   if (!user) {
     return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
   }
@@ -54,7 +54,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
-  const user = getUserFromRequest(request);
+  const user = await getUserFromRequest(request);
   if (!user) {
     return NextResponse.json({ error: "Não autenticado" }, { status: 401 });
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,10 +47,37 @@
 }
 
 body {
-  background-color: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-geist-sans), system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", sans-serif;
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(11, 29, 63, 0.9), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(246, 196, 109, 0.22), transparent 55%),
+    linear-gradient(135deg, var(--color-deep-night) 0%, #081a39 55%, var(--color-midnight) 100%);
+  color: var(--color-text-primary);
+  font-family: var(--font-poppins), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  text-rendering: optimizeLegibility;
+  background-attachment: fixed;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a,
+button,
+[role="button"] {
+  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease,
+    box-shadow 150ms ease, transform 200ms ease;
+}
+
+::selection {
+  background: rgba(246, 196, 109, 0.35);
+  color: var(--color-deep-night);
+}
+
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-deep-night), 0 0 0 4px var(--color-focus-ring);
 }
 
 .bg-sentinel-gradient {
@@ -78,35 +105,4 @@ body {
 
 .text-sentinel-foreground {
   color: var(--foreground);
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: radial-gradient(circle at top left, rgba(11, 29, 63, 0.9), transparent 45%),
-    radial-gradient(circle at 80% 10%, rgba(246, 196, 109, 0.22), transparent 55%),
-    linear-gradient(135deg, var(--color-deep-night) 0%, #081a39 55%, var(--color-midnight) 100%);
-  color: var(--color-text-primary);
-  font-family: var(--font-poppins), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  text-rendering: optimizeLegibility;
-  background-attachment: fixed;
-}
-
-a {
-  color: inherit;
-}
-
-a,
-button,
-[role="button"] {
-  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease,
-    box-shadow 150ms ease, transform 200ms ease;
-}
-
-::selection {
-  background: rgba(246, 196, 109, 0.35);
-  color: var(--color-deep-night);
-}
-
-:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-deep-night), 0 0 0 4px var(--color-focus-ring);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,23 +14,34 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const description = "Plataforma de monitoramento inteligente Sentinela.";
+const defaultTitle = "Sentinela – Monitoramento Inteligente de Bem-estar";
+const description =
+  "Check-ins diários e analytics preventivos para mapear estresse e orientar ações rápidas com total conformidade.";
 
 export const metadata: Metadata = {
   title: {
-    default: "Sentinela",
+    default: defaultTitle,
     template: "%s | Sentinela",
   },
   description,
   metadataBase: new URL("https://sentinela.example.com"),
   openGraph: {
-    title: "Sentinela",
+    title: defaultTitle,
     description,
     url: "https://sentinela.example.com",
     siteName: "Sentinela",
     locale: "pt_BR",
     type: "website",
   },
+  twitter: {
+    card: "summary_large_image",
+    title: defaultTitle,
+    description,
+  },
+  icons: {
+    icon: "/favicon.ico",
+  },
+  themeColor: "#07132b",
 };
 
 export default function RootLayout({
@@ -40,9 +51,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pt-BR">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-sentinel-canvas text-sentinel-foreground`}
-      >
+      <body className={`${poppins.variable} ${geistMono.variable} antialiased bg-sentinel-canvas text-sentinel-foreground`}>
         <div className="min-h-screen bg-sentinel-gradient">
           {children}
         </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,6 @@
+import { cookies, headers } from "next/headers";
+import { redirect } from "next/navigation";
+import type { NextRequest } from "next/server";
 import { SignJWT, jwtVerify } from "jose";
 
 export const SESSION_COOKIE_NAME = "sentinela-session";
@@ -8,6 +11,12 @@ const secretKey = new TextEncoder().encode(secret);
 
 export interface SessionPayload {
   sub: string;
+  email: string;
+  name: string;
+}
+
+export interface AuthenticatedUser {
+  id: string;
   email: string;
   name: string;
 }
@@ -39,4 +48,71 @@ export async function verifySessionToken(token: string): Promise<SessionPayload 
   } catch (error) {
     return null;
   }
+}
+
+function sessionToUser(session: SessionPayload | null): AuthenticatedUser | null {
+  if (!session) {
+    return null;
+  }
+
+  return {
+    id: session.sub,
+    email: session.email,
+    name: session.name,
+  };
+}
+
+function getUserFromHeaderBag(headerBag: Headers): AuthenticatedUser | null {
+  const id = headerBag.get("x-user-id");
+  const email = headerBag.get("x-user-email");
+  const name = headerBag.get("x-user-name");
+
+  if (!id || !email || !name) {
+    return null;
+  }
+
+  return { id, email, name };
+}
+
+async function getUserFromCookiesStore(): Promise<AuthenticatedUser | null> {
+  const cookieStore = cookies();
+  const sessionToken = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+
+  if (!sessionToken) {
+    return null;
+  }
+
+  const session = await verifySessionToken(sessionToken);
+  return sessionToUser(session);
+}
+
+export async function getUserFromRequest(request: NextRequest): Promise<AuthenticatedUser | null> {
+  const fromHeaders = getUserFromHeaderBag(request.headers);
+  if (fromHeaders) {
+    return fromHeaders;
+  }
+
+  const sessionToken = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+  if (!sessionToken) {
+    return null;
+  }
+
+  const session = await verifySessionToken(sessionToken);
+  return sessionToUser(session);
+}
+
+export async function requireUser(): Promise<AuthenticatedUser> {
+  const headerStore = headers();
+  const fromHeaders = getUserFromHeaderBag(headerStore);
+
+  if (fromHeaders) {
+    return fromHeaders;
+  }
+
+  const user = await getUserFromCookiesStore();
+  if (user) {
+    return user;
+  }
+
+  redirect("/");
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,6 +11,16 @@ export interface UserRecord {
   createdAt: string;
 }
 
+export interface CheckInRecord {
+  id: number;
+  userId: number;
+  date: string;
+  moodScore: number;
+  stressScore: number;
+  notes: string | null;
+  createdAt: string;
+}
+
 const dataDirectory = path.join(process.cwd(), "data");
 const databasePath = path.join(dataDirectory, "sentinela.db");
 
@@ -30,6 +40,19 @@ database.exec(`
     passwordHash TEXT NOT NULL,
     createdAt TEXT NOT NULL DEFAULT (datetime('now'))
   );
+
+  CREATE TABLE IF NOT EXISTS check_ins (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    date TEXT NOT NULL,
+    moodScore INTEGER NOT NULL CHECK(moodScore BETWEEN 1 AND 5),
+    stressScore INTEGER NOT NULL CHECK(stressScore BETWEEN 1 AND 10),
+    notes TEXT,
+    createdAt TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_check_ins_user_date
+    ON check_ins(userId, datetime(date));
 `);
 
 export function getUserByEmail(email: string): UserRecord | undefined {
@@ -55,6 +78,76 @@ export function createUser(user: {
     "SELECT id, name, age, email, passwordHash, createdAt FROM users WHERE id = ?"
   );
   return select.get(Number(info.lastInsertRowid)) as UserRecord;
+}
+
+function toNumberId(userId: string | number): number {
+  const parsed = typeof userId === "number" ? userId : Number.parseInt(userId, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error("Invalid user id for check-in operation");
+  }
+  return parsed;
+}
+
+export function insertCheckIn(checkIn: {
+  userId: string | number;
+  date: string;
+  moodScore: number;
+  stressScore: number;
+  notes: string | null;
+}): CheckInRecord {
+  const insert = database.prepare(
+    `INSERT INTO check_ins (userId, date, moodScore, stressScore, notes, createdAt)
+     VALUES (@userId, @date, @moodScore, @stressScore, @notes, datetime('now'))`
+  );
+
+  const payload = {
+    ...checkIn,
+    userId: toNumberId(checkIn.userId),
+  };
+
+  const info = insert.run(payload);
+  const select = database.prepare(
+    `SELECT id, userId, date, moodScore, stressScore, notes, createdAt
+       FROM check_ins WHERE id = ?`
+  );
+  return select.get(Number(info.lastInsertRowid)) as CheckInRecord;
+}
+
+export function listCheckInsByUser(userId: string | number): CheckInRecord[] {
+  const statement = database.prepare(
+    `SELECT id, userId, date, moodScore, stressScore, notes, createdAt
+       FROM check_ins
+       WHERE userId = ?
+       ORDER BY datetime(date) DESC`
+  );
+
+  return statement.all(toNumberId(userId)) as CheckInRecord[];
+}
+
+export function listCheckInsByUserSince(
+  userId: string | number,
+  sinceISODate: string
+): CheckInRecord[] {
+  const statement = database.prepare(
+    `SELECT id, userId, date, moodScore, stressScore, notes, createdAt
+       FROM check_ins
+       WHERE userId = ? AND datetime(date) >= datetime(?)
+       ORDER BY datetime(date) DESC`
+  );
+
+  return statement.all(toNumberId(userId), sinceISODate) as CheckInRecord[];
+}
+
+export function findLatestCheckIn(userId: string | number): CheckInRecord | undefined {
+  const statement = database.prepare(
+    `SELECT id, userId, date, moodScore, stressScore, notes, createdAt
+       FROM check_ins
+       WHERE userId = ?
+       ORDER BY datetime(date) DESC
+       LIMIT 1`
+  );
+
+  return statement.get(toNumberId(userId)) as CheckInRecord | undefined;
 }
 
 export default database;


### PR DESCRIPTION
## Summary
- recreate the SQLite schema and helpers for user check-ins that were dropped in recent merges
- rebuild the auth utilities so server components and API routes can recover the logged-in user
- realign global styles and metadata with the Sentinela branding

## Testing
- npm run build *(fails: missing native modules such as better-sqlite3 and blocked Google Fonts downloads in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d0c9c8248332a2f04009d36d8365