### PR TITLE
Fix dashboard route returning 404

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DashboardPage() {
+  redirect("/home");
+}


### PR DESCRIPTION
## Summary
- add a dashboard route within the dashboard layout group
- redirect dashboard requests to the existing home dashboard page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5dd910dfc83328e0a3fead4222624