### PR TITLE
Fix session expiration handling

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -29,7 +29,7 @@ export async function createSessionToken(payload: SessionPayload): Promise<strin
     .setProtectedHeader({ alg: "HS256", typ: "JWT" })
     .setSubject(payload.sub)
     .setIssuedAt()
-    .setExpirationTime(DEFAULT_EXPIRATION)
+    .setExpirationTime(`${DEFAULT_EXPIRATION}s`)
     .sign(secretKey);
 }
 


### PR DESCRIPTION
## Summary
- ensure JWT session tokens use a relative expiration expression so they stay valid
- keep the existing cookie lifetime aligned with the seven-day session window

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5de9431bc8332a185cc77dbbcd4cf