### PR TITLE
Implement email verification flow for new accounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Credenciais do Outlook utilizadas para envio de e-mails de verificação
+OUTLOOK_EMAIL=""
+OUTLOOK_PASSWORD=""
+# Opcional: personalize o host/porta SMTP do Outlook
+OUTLOOK_SMTP_HOST="smtp.office365.com"
+OUTLOOK_SMTP_PORT="587"
+
+# Chave utilizada para assinar os tokens de sessão
+AUTH_SECRET=""
+
+# URL base da aplicação (utilizada em links gerados no servidor)
+APP_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,3 +1,4 @@
+import "./src/lib/env";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.4.1",
+        "dotenv": "^17.2.3",
         "jose": "^6.1.0",
         "next": "15.5.4",
+        "nodemailer": "^7.0.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "recharts": "^2.12.7",
@@ -1204,6 +1206,133 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -1237,6 +1366,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -1260,6 +1411,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1267,6 +1424,15 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fast-equals": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.3.2.tgz",
+      "integrity": "sha512-6rxyATwPCkaFIL3JLqw8qXqMpIZ942pTX/tbQFkRsDGblS8tNGtlUauA/+mt6RUfqn/4MoEr+WDkYoIQbibWuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -1326,6 +1492,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -1344,6 +1519,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",
@@ -1798,6 +1979,24 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/nodemailer": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.9.tgz",
+      "integrity": "sha512-9/Qm0qXIByEP8lEV2qOqcAW7bRpL8CR9jcTwk3NBnHJNmP9fIJ86g2fgmIXqHY+nj55ZEMwWqYAT2QTDpRUYiQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1868,6 +2067,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -1914,6 +2130,43 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -1926,6 +2179,38 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/safe-buffer": {
@@ -2176,6 +2461,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2220,6 +2511,41 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.4.1",
+    "dotenv": "^17.2.3",
     "jose": "^6.1.0",
     "next": "15.5.4",
+    "nodemailer": "^7.0.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "recharts": "^2.12.7",

--- a/src/app/(auth)/_components/RegisterForm.tsx
+++ b/src/app/(auth)/_components/RegisterForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { calculateAgeFromBirthDate } from "@/lib/date";
 
@@ -11,6 +11,15 @@ interface FormState {
   email: string;
   password: string;
 }
+
+interface VerificationDetails {
+  email: string;
+  sentAt: string | null;
+  resendAvailableAt: string;
+  resendIntervalMs: number;
+}
+
+type ApiError = Error & { details?: unknown };
 
 const INITIAL_STATE: FormState = {
   name: "",
@@ -23,6 +32,16 @@ function validateEmail(email: string) {
   return /\S+@\S+\.\S+/.test(email);
 }
 
+function parseApiError(response: Response, fallbackMessage: string) {
+  return response
+    .json()
+    .catch(() => ({ message: fallbackMessage }))
+    .then((errorBody) => ({
+      message: errorBody?.message ?? fallbackMessage,
+      details: errorBody,
+    }));
+}
+
 async function registerRequest(payload: { name: string; birthDate: string; email: string; password: string }) {
   const response = await fetch("/api/auth/register", {
     method: "POST",
@@ -33,18 +52,91 @@ async function registerRequest(payload: { name: string; birthDate: string; email
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: "Não foi possível criar conta." }));
-    throw new Error(error.message ?? "Não foi possível criar conta.");
+    const error = await parseApiError(response, "Não foi possível criar conta.");
+    const apiError = new Error(error.message) as ApiError;
+    apiError.details = error.details;
+    throw apiError;
+  }
+
+  return (await response.json()) as { message: string; verification: VerificationDetails };
+}
+
+async function verifyCodeRequest(payload: { email: string; code: string }) {
+  const response = await fetch("/api/auth/register/verify", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await parseApiError(response, "Não foi possível validar o código informado.");
+    const apiError = new Error(error.message) as ApiError;
+    apiError.details = error.details;
+    throw apiError;
   }
 
   return response.json();
 }
 
+async function resendCodeRequest(payload: { email: string }) {
+  const response = await fetch("/api/auth/register/resend", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const body = await response.json().catch(() => ({ message: "Não foi possível reenviar o código." }));
+
+  if (!response.ok) {
+    const error = new Error(body?.message ?? "Não foi possível reenviar o código.") as ApiError;
+    error.details = body;
+    throw error;
+  }
+
+  return body as { message: string; verification: VerificationDetails };
+}
+
+function formatCountdown(ms: number) {
+  if (ms <= 0) {
+    return "00:00";
+  }
+
+  const totalSeconds = Math.ceil(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
 export function RegisterForm() {
   const [form, setForm] = useState<FormState>(INITIAL_STATE);
+  const [step, setStep] = useState<"form" | "verify">("form");
+  const [verificationDetails, setVerificationDetails] = useState<VerificationDetails | null>(null);
+  const [verificationCode, setVerificationCode] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!verificationDetails) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setNow(Date.now());
+    }, 500);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [verificationDetails]);
 
   const isEmailValid = useMemo(() => !form.email || validateEmail(form.email), [form.email]);
   const birthDateErrorMessage = useMemo(() => {
@@ -83,6 +175,28 @@ export function RegisterForm() {
     return reference.toISOString().slice(0, 10);
   }, []);
 
+  const resendRemainingMs = useMemo(() => {
+    if (!verificationDetails) {
+      return 0;
+    }
+
+    const availableTime = new Date(verificationDetails.resendAvailableAt).getTime();
+
+    if (Number.isNaN(availableTime)) {
+      return 0;
+    }
+
+    return Math.max(0, availableTime - now);
+  }, [verificationDetails, now]);
+
+  const canResend = resendRemainingMs <= 0;
+  const resendCountdown = useMemo(() => formatCountdown(resendRemainingMs), [resendRemainingMs]);
+
+  const headerTitle = step === "verify" ? "Confirme seu e-mail" : "Crie sua conta Sentinela";
+  const headerDescription = step === "verify"
+    ? `Enviamos um código de verificação para ${verificationDetails?.email ?? "o e-mail informado"}.`
+    : "Preencha os dados abaixo para iniciar seu monitoramento inteligente.";
+
   const handleChange = (field: keyof FormState) => (event: React.ChangeEvent<HTMLInputElement>) => {
     setForm((previous) => ({ ...previous, [field]: event.target.value }));
   };
@@ -114,13 +228,17 @@ export function RegisterForm() {
 
     setIsLoading(true);
     try {
-      await registerRequest({
+      const response = await registerRequest({
         name: form.name.trim(),
         birthDate: form.birthDate,
         email: form.email.toLowerCase(),
         password: form.password,
       });
-      setSuccess("Conta criada com sucesso! Você já pode acessar o painel.");
+
+      setVerificationDetails(response.verification);
+      setVerificationCode("");
+      setSuccess(response.message);
+      setStep("verify");
       setForm(INITIAL_STATE);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Não foi possível criar conta.");
@@ -129,101 +247,222 @@ export function RegisterForm() {
     }
   };
 
+  const handleVerifySubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (!verificationDetails) {
+      setError("Não encontramos uma solicitação de verificação.");
+      return;
+    }
+
+    if (!verificationCode.trim()) {
+      setError("Informe o código recebido por e-mail.");
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      await verifyCodeRequest({ email: verificationDetails.email, code: verificationCode.trim() });
+      setSuccess("Conta confirmada com sucesso! Redirecionando para o painel...");
+      setTimeout(() => {
+        window.location.href = "/dashboard";
+      }, 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Não foi possível validar o código informado.");
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleResendCode = async () => {
+    if (!verificationDetails || !canResend) {
+      return;
+    }
+
+    setError(null);
+    setSuccess(null);
+    setIsResending(true);
+
+    try {
+      const response = await resendCodeRequest({ email: verificationDetails.email });
+      setVerificationDetails(response.verification);
+      setSuccess(response.message);
+    } catch (err) {
+      const apiError = err as ApiError;
+      const details = apiError.details as { verification?: VerificationDetails } | undefined;
+
+      if (details?.verification) {
+        setVerificationDetails(details.verification);
+      }
+
+      setError(apiError.message ?? "Não foi possível reenviar o código.");
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  const handleEditInformation = () => {
+    setStep("form");
+    setError(null);
+    setSuccess(null);
+    setVerificationCode("");
+  };
+
   return (
     <div className="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl backdrop-blur">
       <header className="space-y-2 text-left">
-        <h2 className="text-3xl font-semibold text-white">Crie sua conta Sentinela</h2>
-        <p className="text-sm text-slate-300">
-          Preencha os dados abaixo para iniciar seu monitoramento inteligente.
-        </p>
+        <h2 className="text-3xl font-semibold text-white">{headerTitle}</h2>
+        <p className="text-sm text-slate-300">{headerDescription}</p>
       </header>
-      <form className="mt-8 space-y-6" onSubmit={handleSubmit} noValidate>
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-slate-200" htmlFor="name">
-            Nome completo
-          </label>
-          <input
-            id="name"
-            type="text"
-            autoComplete="name"
-            className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
-            placeholder="Como prefere ser chamado?"
-            value={form.name}
-            onChange={handleChange("name")}
-            required
-          />
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-slate-200" htmlFor="birthDate">
-            Data de nascimento
-          </label>
-          <input
-            id="birthDate"
-            type="date"
-            autoComplete="bday"
-            max={maxBirthDate}
-            className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
-            value={form.birthDate}
-            onChange={handleChange("birthDate")}
-            required
-          />
-          {birthDateErrorMessage ? (
-            <p className="text-xs text-red-200">{birthDateErrorMessage}</p>
+
+      {step === "form" ? (
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit} noValidate>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-slate-200" htmlFor="name">
+              Nome completo
+            </label>
+            <input
+              id="name"
+              type="text"
+              autoComplete="name"
+              className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
+              placeholder="Como prefere ser chamado?"
+              value={form.name}
+              onChange={handleChange("name")}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-slate-200" htmlFor="birthDate">
+              Data de nascimento
+            </label>
+            <input
+              id="birthDate"
+              type="date"
+              autoComplete="bday"
+              max={maxBirthDate}
+              className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
+              value={form.birthDate}
+              onChange={handleChange("birthDate")}
+              required
+            />
+            {birthDateErrorMessage ? (
+              <p className="text-xs text-red-200">{birthDateErrorMessage}</p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-slate-200" htmlFor="email">
+              E-mail
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
+              placeholder="nome@empresa.com"
+              value={form.email}
+              onChange={handleChange("email")}
+              required
+            />
+            {!isEmailValid && <p className="text-xs text-red-200">Informe um e-mail válido.</p>}
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-slate-200" htmlFor="password">
+              Senha
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              minLength={8}
+              className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
+              placeholder="Crie uma senha segura"
+              value={form.password}
+              onChange={handleChange("password")}
+              required
+            />
+            {passwordErrorMessage ? <p className="text-xs text-red-200">{passwordErrorMessage}</p> : null}
+          </div>
+          {error ? (
+            <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</p>
           ) : null}
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-slate-200" htmlFor="email">
-            E-mail
-          </label>
-          <input
-            id="email"
-            type="email"
-            autoComplete="email"
-            className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
-            placeholder="nome@empresa.com"
-            value={form.email}
-            onChange={handleChange("email")}
-            required
-          />
-          {!isEmailValid && (
-            <p className="text-xs text-red-200">Informe um e-mail válido.</p>
-          )}
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-slate-200" htmlFor="password">
-            Senha
-          </label>
-          <input
-            id="password"
-            type="password"
-            autoComplete="new-password"
-            minLength={8}
-            className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-sm text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
-            placeholder="Crie uma senha segura"
-            value={form.password}
-            onChange={handleChange("password")}
-            required
-          />
-          {passwordErrorMessage ? (
-            <p className="text-xs text-red-200">{passwordErrorMessage}</p>
+          {success ? (
+            <p className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+              {success}
+            </p>
           ) : null}
-        </div>
-        {error ? (
-          <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</p>
-        ) : null}
-        {success ? (
-          <p className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
-            {success}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-emerald-400 to-emerald-500 px-4 py-3 text-sm font-semibold text-slate-900 transition focus:outline-none focus:ring-2 focus:ring-emerald-200 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isLoading ? "Enviando..." : "Criar conta"}
+          </button>
+        </form>
+      ) : (
+        <form className="mt-8 space-y-6" onSubmit={handleVerifySubmit} noValidate>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-slate-200" htmlFor="verificationCode">
+              Código de verificação
+            </label>
+            <input
+              id="verificationCode"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              pattern="[0-9]{6}"
+              maxLength={6}
+              className="w-full rounded-xl border border-white/10 bg-[#090f1f]/70 px-4 py-3 text-center text-lg font-semibold tracking-[0.5em] text-white outline-none transition focus:border-emerald-400/60 focus:ring-2 focus:ring-emerald-400/40"
+              placeholder="000000"
+              value={verificationCode}
+              onChange={(event) => setVerificationCode(event.target.value.replace(/\D/g, ""))}
+              required
+            />
+          </div>
+          {error ? (
+            <p className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</p>
+          ) : null}
+          {success ? (
+            <p className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
+              {success}
+            </p>
+          ) : null}
+          <div className="space-y-3">
+            <button
+              type="submit"
+              disabled={isVerifying}
+              className="flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-emerald-400 to-emerald-500 px-4 py-3 text-sm font-semibold text-slate-900 transition focus:outline-none focus:ring-2 focus:ring-emerald-200 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isVerifying ? "Validando..." : "Confirmar código"}
+            </button>
+            <button
+              type="button"
+              onClick={handleResendCode}
+              disabled={!canResend || isResending}
+              className="flex w-full items-center justify-center rounded-xl border border-emerald-300/40 px-4 py-3 text-sm font-semibold text-emerald-200 transition focus:outline-none focus:ring-2 focus:ring-emerald-200 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isResending
+                ? "Reenviando..."
+                : canResend
+                ? "Reenviar código"
+                : `Reenviar em ${resendCountdown}`}
+            </button>
+          </div>
+          <p className="text-center text-xs text-slate-300">
+            Informações incorretas?{" "}
+            <button
+              type="button"
+              onClick={handleEditInformation}
+              className="font-semibold text-emerald-200 hover:text-emerald-100"
+            >
+              Voltar e ajustar cadastro
+            </button>
           </p>
-        ) : null}
-        <button
-          type="submit"
-          disabled={isLoading}
-          className="flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-emerald-400 to-emerald-500 px-4 py-3 text-sm font-semibold text-slate-900 transition focus:outline-none focus:ring-2 focus:ring-emerald-200 disabled:cursor-not-allowed disabled:opacity-70"
-        >
-          {isLoading ? "Enviando..." : "Criar conta"}
-        </button>
-      </form>
+        </form>
+      )}
+
       <footer className="mt-8 text-center text-sm text-slate-300">
         Já possui acesso?{" "}
         <Link href="/" className="font-medium text-emerald-300 hover:text-emerald-200">

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -35,6 +35,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  if (user.status !== "active") {
+    return NextResponse.json(
+      {
+        message: "Confirme seu e-mail antes de acessar o Sentinela.",
+      },
+      { status: 403 }
+    );
+  }
+
   const isPasswordValid = await bcrypt.compare(password, user.passwordHash);
 
   if (!isPasswordValid) {

--- a/src/app/api/auth/register/resend/route.ts
+++ b/src/app/api/auth/register/resend/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getUserByEmail, refreshVerificationCode } from "@/lib/db";
+import { sendVerificationCodeEmail } from "@/lib/email";
+import {
+  VERIFICATION_RESEND_INTERVAL_MS,
+  calculateResendAvailableAt,
+  canResendVerification,
+  generateVerificationCode,
+} from "@/lib/verification";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null);
+  const email = body?.email?.toLowerCase().trim();
+
+  if (!email) {
+    return NextResponse.json(
+      {
+        message: "Informe um e-mail válido.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const user = getUserByEmail(email);
+
+  if (!user || user.status !== "pending_verification") {
+    return NextResponse.json(
+      {
+        message: "Não encontramos uma conta pendente para este e-mail.",
+      },
+      { status: 404 }
+    );
+  }
+
+  if (!canResendVerification(user.verificationCodeSentAt)) {
+    const resendAvailableAt = user.verificationCodeSentAt
+      ? calculateResendAvailableAt(user.verificationCodeSentAt)
+      : calculateResendAvailableAt(new Date().toISOString());
+
+    return NextResponse.json(
+      {
+        message: "O código só pode ser reenviado após aguardar 2 minutos.",
+        verification: {
+          email,
+          sentAt: user.verificationCodeSentAt,
+          resendAvailableAt,
+          resendIntervalMs: VERIFICATION_RESEND_INTERVAL_MS,
+        },
+      },
+      { status: 429 }
+    );
+  }
+
+  const verificationCode = generateVerificationCode();
+  const sentAt = new Date().toISOString();
+
+  try {
+    const updatedUser = refreshVerificationCode({
+      id: user.id,
+      verificationCode,
+      verificationCodeSentAt: sentAt,
+    });
+
+    await sendVerificationCodeEmail({
+      to: updatedUser.email,
+      name: updatedUser.name,
+      code: verificationCode,
+    });
+
+    return NextResponse.json({
+      message: "Enviamos um novo código de verificação para o seu e-mail.",
+      verification: {
+        email,
+        sentAt,
+        resendAvailableAt: calculateResendAvailableAt(sentAt),
+        resendIntervalMs: VERIFICATION_RESEND_INTERVAL_MS,
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        message: "Não foi possível enviar o novo código agora. Tente novamente em instantes.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/register/verify/route.ts
+++ b/src/app/api/auth/register/verify/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { DEFAULT_EXPIRATION, SESSION_COOKIE_NAME, createSessionToken } from "@/lib/auth";
+import { getUserByEmail, markUserAsVerified } from "@/lib/db";
+import { calculateAgeFromBirthDate } from "@/lib/date";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => null);
+
+  const email = body?.email?.toLowerCase().trim();
+  const code = body?.code?.trim();
+
+  if (!email || !code) {
+    return NextResponse.json(
+      {
+        message: "Informe e-mail e código de verificação válidos.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const user = getUserByEmail(email);
+
+  if (!user || user.status !== "pending_verification" || !user.verificationCode) {
+    return NextResponse.json(
+      {
+        message: "Não encontramos uma conta pendente para este e-mail.",
+      },
+      { status: 404 }
+    );
+  }
+
+  if (user.verificationCode !== code) {
+    return NextResponse.json(
+      {
+        message: "Código de verificação inválido.",
+      },
+      { status: 400 }
+    );
+  }
+
+  const updatedUser = markUserAsVerified(user.id);
+
+  const token = await createSessionToken({
+    sub: String(updatedUser.id),
+    email: updatedUser.email,
+    name: updatedUser.name,
+  });
+
+  const age = calculateAgeFromBirthDate(updatedUser.birthDate);
+
+  const response = NextResponse.json({
+    user: {
+      id: updatedUser.id,
+      name: updatedUser.name,
+      email: updatedUser.email,
+      birthDate: updatedUser.birthDate,
+      age,
+      createdAt: updatedUser.createdAt,
+    },
+  });
+
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: DEFAULT_EXPIRATION,
+  });
+
+  return response;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,11 +2,12 @@ import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { NextRequest } from "next/server";
 import { SignJWT, jwtVerify } from "jose";
+import { getEnv } from "./env";
 
 export const SESSION_COOKIE_NAME = "sentinela-session";
 export const DEFAULT_EXPIRATION = 60 * 60 * 24 * 7; // 7 dias
 
-const secret = process.env.AUTH_SECRET ?? "sentinela-development-secret";
+const secret = getEnv("AUTH_SECRET") ?? "sentinela-development-secret";
 const secretKey = new TextEncoder().encode(secret);
 
 export interface SessionPayload {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,62 @@
+import nodemailer from "nodemailer";
+import { getEnv, getRequiredEnv } from "./env";
+
+let cachedTransporter: nodemailer.Transporter | null = null;
+let cachedSender: string | null = null;
+
+function resolveTransporter() {
+  if (cachedTransporter && cachedSender) {
+    return { transporter: cachedTransporter, sender: cachedSender };
+  }
+
+  const outlookEmail = getRequiredEnv("OUTLOOK_EMAIL");
+  const outlookPassword = getRequiredEnv("OUTLOOK_PASSWORD");
+  const outlookHost = getEnv("OUTLOOK_SMTP_HOST") ?? "smtp.office365.com";
+  const outlookPort = Number.parseInt(getEnv("OUTLOOK_SMTP_PORT") ?? "587", 10);
+
+  cachedTransporter = nodemailer.createTransport({
+    host: outlookHost,
+    port: outlookPort,
+    secure: outlookPort === 465,
+    auth: {
+      user: outlookEmail,
+      pass: outlookPassword,
+    },
+  });
+
+  cachedSender = outlookEmail;
+
+  return { transporter: cachedTransporter, sender: cachedSender };
+}
+
+export async function sendVerificationCodeEmail(params: {
+  to: string;
+  name: string;
+  code: string;
+}): Promise<void> {
+  const { transporter, sender } = resolveTransporter();
+  const { to, name, code } = params;
+
+  await transporter.sendMail({
+    from: {
+      name: "Sentinela",
+      address: sender,
+    },
+    to,
+    subject: "Código de verificação — Sentinela",
+    text: `Olá, ${name}!\n\nUse o código ${code} para confirmar seu cadastro no Sentinela.\n\nSe você não solicitou esta conta, ignore este e-mail.`,
+    html: `
+      <div style="font-family: Arial, Helvetica, sans-serif; line-height: 1.5; color: #0f172a;">
+        <p>Olá, <strong>${name}</strong>!</p>
+        <p>
+          Use o código abaixo para confirmar seu cadastro no <strong>Sentinela</strong>.
+        </p>
+        <p style="font-size: 24px; font-weight: bold; letter-spacing: 8px; margin: 24px 0;">
+          ${code}
+        </p>
+        <p>Se você não solicitou esta conta, ignore esta mensagem.</p>
+        <p style="margin-top: 32px; font-size: 12px; color: #64748b;">Este código expira em alguns minutos.</p>
+      </div>
+    `,
+  });
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,18 @@
+import "dotenv/config";
+
+function formatEnvError(name: string): string {
+  return `A variável de ambiente ${name} é obrigatória. Defina-a no arquivo .env.`;
+}
+
+export function getEnv(name: string): string | undefined {
+  return process.env[name];
+}
+
+export function getRequiredEnv(name: string): string {
+  const value = getEnv(name);
+  if (!value) {
+    throw new Error(formatEnvError(name));
+  }
+
+  return value;
+}

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -1,0 +1,34 @@
+export const VERIFICATION_CODE_LENGTH = 6;
+export const VERIFICATION_RESEND_INTERVAL_MS = 2 * 60 * 1000; // 2 minutos
+
+export function generateVerificationCode(): string {
+  const min = 10 ** (VERIFICATION_CODE_LENGTH - 1);
+  const max = 10 ** VERIFICATION_CODE_LENGTH;
+  const code = Math.floor(Math.random() * (max - min)) + min;
+  return String(code).padStart(VERIFICATION_CODE_LENGTH, "0");
+}
+
+export function calculateResendAvailableAt(sentAtISO: string): string {
+  const sentAt = new Date(sentAtISO);
+  if (Number.isNaN(sentAt.getTime())) {
+    return new Date(Date.now() + VERIFICATION_RESEND_INTERVAL_MS).toISOString();
+  }
+
+  return new Date(sentAt.getTime() + VERIFICATION_RESEND_INTERVAL_MS).toISOString();
+}
+
+export function canResendVerification(
+  sentAtISO: string | null | undefined,
+  now: Date = new Date()
+): boolean {
+  if (!sentAtISO) {
+    return true;
+  }
+
+  const sentAt = new Date(sentAtISO);
+  if (Number.isNaN(sentAt.getTime())) {
+    return true;
+  }
+
+  return now.getTime() - sentAt.getTime() >= VERIFICATION_RESEND_INTERVAL_MS;
+}


### PR DESCRIPTION
## Summary
- add an Outlook-based email verification workflow with resend support
- persist verification metadata in SQLite and block login until confirmation
- update the registration UI to handle code entry and resend timing
- load dotenv configuration automatically and document required secrets in .env.example

## Testing
- npm run build *(fails: Next.js fonts blocked by sandbox network policy)*

------
https://chatgpt.com/codex/tasks/task_e_68e6680cb4908332a7eab925d2981e19