### PR TITLE
Add OAuth2 support for Outlook email sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,15 @@
-# Credenciais do Outlook utilizadas para envio de e-mails de verificação
 OUTLOOK_EMAIL=""
+# Informe OUTLOOK_PASSWORD apenas se a autenticação básica estiver habilitada para a conta.
 OUTLOOK_PASSWORD=""
-# Opcional: personalize o host/porta SMTP do Outlook
+
+# Para autenticação moderna (recomendada quando a autenticação básica está desativada),
+# configure as variáveis abaixo com os dados do aplicativo registrado no Azure AD.
+OUTLOOK_TENANT_ID=""
+OUTLOOK_CLIENT_ID=""
+OUTLOOK_CLIENT_SECRET=""
+# Opcional: ajuste o escopo utilizado para solicitar o token OAuth2.
+# OUTLOOK_OAUTH_SCOPE="https://outlook.office365.com/.default"
+
 OUTLOOK_SMTP_HOST="smtp.office365.com"
 OUTLOOK_SMTP_PORT="587"
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,22 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Configuração do envio de e-mails
+
+O projeto utiliza o Outlook SMTP para envio de e-mails transacionais. Preencha as variáveis
+de ambiente no arquivo `.env` conforme o cenário da sua conta:
+
+- **Autenticação básica habilitada**: informe `OUTLOOK_EMAIL` e `OUTLOOK_PASSWORD` (senha de
+  aplicativo). Esse modo só funciona se o recurso estiver disponível na conta.
+- **Autenticação básica desabilitada (cenário padrão)**: cadastre um aplicativo no Azure AD,
+  conceda a permissão `SMTP.Send` (ou `Mail.Send`) e configure `OUTLOOK_TENANT_ID`,
+  `OUTLOOK_CLIENT_ID` e `OUTLOOK_CLIENT_SECRET`. Opcionalmente ajuste
+  `OUTLOOK_OAUTH_SCOPE` caso utilize um escopo diferente de
+  `https://outlook.office365.com/.default`.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-"# Sentinela" 
+"# Sentinela"

--- a/src/lib/outlook-oauth.ts
+++ b/src/lib/outlook-oauth.ts
@@ -1,0 +1,118 @@
+import { getEnv, getRequiredEnv } from "./env";
+
+type CachedToken = {
+  accessToken: string;
+  expiresAt: number;
+};
+
+let cachedToken: CachedToken | null = null;
+let pendingTokenPromise: Promise<string> | null = null;
+
+export function isOutlookOAuthConfigured(): boolean {
+  return (
+    Boolean(getEnv("OUTLOOK_CLIENT_ID")) &&
+    Boolean(getEnv("OUTLOOK_CLIENT_SECRET")) &&
+    Boolean(getEnv("OUTLOOK_TENANT_ID"))
+  );
+}
+
+function getOAuthScope(): string {
+  return getEnv("OUTLOOK_OAUTH_SCOPE") ?? "https://outlook.office365.com/.default";
+}
+
+async function requestNewToken(): Promise<string> {
+  const tenantId = getRequiredEnv("OUTLOOK_TENANT_ID");
+  const clientId = getRequiredEnv("OUTLOOK_CLIENT_ID");
+  const clientSecret = getRequiredEnv("OUTLOOK_CLIENT_SECRET");
+  const scope = getOAuthScope();
+
+  const tokenEndpoint = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "client_credentials",
+    scope,
+  });
+
+  const response = await fetch(tokenEndpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    let errorMessage: string;
+    try {
+      const errorBody = await response.json();
+      const description =
+        typeof errorBody?.error_description === "string"
+          ? errorBody.error_description
+          : undefined;
+      const error = typeof errorBody?.error === "string" ? errorBody.error : undefined;
+      errorMessage = description ?? error ?? response.statusText;
+    } catch (error) {
+      const fallback = await response.text();
+      errorMessage = fallback || (error instanceof Error ? error.message : "Erro desconhecido");
+    }
+
+    throw new Error(
+      `Não foi possível obter um token OAuth2 para o Outlook. Detalhes: ${errorMessage}.`,
+    );
+  }
+
+  const payload: unknown = await response.json();
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    !("access_token" in payload) ||
+    typeof (payload as { access_token: unknown }).access_token !== "string"
+  ) {
+    throw new Error("A resposta do provedor OAuth2 do Outlook não contém um access_token válido.");
+  }
+
+  const { access_token: accessToken } = payload as { access_token: string; expires_in?: unknown };
+  let expiresInSeconds = 3600;
+
+  if ("expires_in" in (payload as Record<string, unknown>)) {
+    const rawExpiresIn = (payload as { expires_in?: unknown }).expires_in;
+    if (typeof rawExpiresIn === "number") {
+      expiresInSeconds = rawExpiresIn;
+    } else if (typeof rawExpiresIn === "string") {
+      const parsed = Number.parseInt(rawExpiresIn, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        expiresInSeconds = parsed;
+      }
+    }
+  }
+
+  const safeExpiresIn = Math.max(expiresInSeconds - 60, 60);
+  cachedToken = {
+    accessToken,
+    expiresAt: Date.now() + safeExpiresIn * 1000,
+  };
+
+  return accessToken;
+}
+
+export async function getOutlookSmtpAccessToken(): Promise<string> {
+  const now = Date.now();
+
+  if (cachedToken && now < cachedToken.expiresAt) {
+    return cachedToken.accessToken;
+  }
+
+  if (pendingTokenPromise) {
+    return pendingTokenPromise;
+  }
+
+  pendingTokenPromise = requestNewToken();
+
+  try {
+    const accessToken = await pendingTokenPromise;
+    return accessToken;
+  } finally {
+    pendingTokenPromise = null;
+  }
+}


### PR DESCRIPTION
## Summary
- add an Outlook OAuth2 token helper and use it when sending e-mails so the app works even when basic auth is disabled
- document the new Outlook OAuth environment variables in `.env.example` and the README

## Testing
- npm run build *(fails in this environment: Next.js cannot download Google Fonts while building with Turbopack)*

------
https://chatgpt.com/codex/tasks/task_e_68e6e2851dc88332938874ef713103fa