### PR TITLE
Configure email sending via Gmail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
-BREVO_SMTP_USER=""
-BREVO_SMTP_KEY=""
-# Opcional: sobrescreva host e porta do SMTP caso necessário.
-# BREVO_SMTP_HOST="smtp-relay.brevo.com"
-# BREVO_SMTP_PORT="587"
+GMAIL_USER=""
+GMAIL_APP_PASSWORD=""
 
 # Chave utilizada para assinar os tokens de sessão
 AUTH_SECRET=""

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Configuração do envio de e-mails
 
-O projeto utiliza o SMTP transacional da [Brevo](https://www.brevo.com/) para envio de e-mails.
+O projeto utiliza o serviço SMTP do Gmail para envio de e-mails.
 Preencha as variáveis de ambiente no arquivo `.env` com as credenciais do serviço:
 
-- `BREVO_SMTP_USER`: o remetente autorizado na Brevo.
-- `BREVO_SMTP_KEY`: a chave SMTP (API Key) gerada na Brevo.
-- Opcionalmente, ajuste `BREVO_SMTP_HOST` e `BREVO_SMTP_PORT` caso utilize valores
-  diferentes do padrão (`smtp-relay.brevo.com:587`).
+- `GMAIL_USER`: o endereço de e-mail que enviará as mensagens.
+- `GMAIL_APP_PASSWORD`: a senha de app gerada no Gmail para autenticação SMTP.
+
+> 💡 Certifique-se de habilitar a verificação em duas etapas na conta do Gmail
+> utilizada e gerar uma senha de app exclusiva para o envio dos e-mails.
 
 ## Deploy on Vercel
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,5 @@
 import nodemailer from "nodemailer";
-import { getEnv, getRequiredEnv } from "./env";
+import { getRequiredEnv } from "./env";
 
 type CachedTransporter = {
   transporter: nodemailer.Transporter;
@@ -9,18 +9,14 @@ type CachedTransporter = {
 let cachedTransporterPromise: Promise<CachedTransporter> | null = null;
 
 async function createTransporter(): Promise<CachedTransporter> {
-  const senderEmail = getRequiredEnv("BREVO_SMTP_USER");
-  const smtpKey = getRequiredEnv("BREVO_SMTP_KEY");
-  const smtpHost = getEnv("BREVO_SMTP_HOST") ?? "smtp-relay.brevo.com";
-  const smtpPort = Number.parseInt(getEnv("BREVO_SMTP_PORT") ?? "587", 10);
+  const senderEmail = getRequiredEnv("GMAIL_USER");
+  const appPassword = getRequiredEnv("GMAIL_APP_PASSWORD");
 
   const transporter = nodemailer.createTransport({
-    host: smtpHost,
-    port: smtpPort,
-    secure: smtpPort === 465,
+    service: "gmail",
     auth: {
       user: senderEmail,
-      pass: smtpKey,
+      pass: appPassword,
     },
   });
 


### PR DESCRIPTION
## Summary
- switch the Nodemailer transporter to authenticate with Gmail SMTP
- document the Gmail credentials required in the README and `.env` example

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e71a11500883329862cd16808f4633