### PR TITLE
Use MailerSend SMTP for email delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-GMAIL_USER=""
-GMAIL_APP_PASSWORD=""
+MAILERSEND_SMTP_USERNAME=""
+MAILERSEND_SMTP_PASSWORD=""
+MAILERSEND_FROM_EMAIL=""
 
 # Chave utilizada para assinar os tokens de sessão
 AUTH_SECRET=""

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Configuração do envio de e-mails
 
-O projeto utiliza o serviço SMTP do Gmail para envio de e-mails.
+O projeto utiliza o serviço SMTP da MailerSend para envio de e-mails.
 Preencha as variáveis de ambiente no arquivo `.env` com as credenciais do serviço:
 
-- `GMAIL_USER`: o endereço de e-mail que enviará as mensagens.
-- `GMAIL_APP_PASSWORD`: a senha de app gerada no Gmail para autenticação SMTP.
+- `MAILERSEND_SMTP_USERNAME`: o usuário SMTP fornecido pela MailerSend.
+- `MAILERSEND_SMTP_PASSWORD`: a senha SMTP fornecida pela MailerSend.
+- `MAILERSEND_FROM_EMAIL`: o endereço de e-mail autorizado no domínio verificado que
+  será exibido como remetente.
 
-> 💡 Certifique-se de habilitar a verificação em duas etapas na conta do Gmail
-> utilizada e gerar uma senha de app exclusiva para o envio dos e-mails.
+> 💡 Gere as credenciais SMTP diretamente no painel da MailerSend e mantenha-as em
+> segurança, pois elas concedem acesso ao envio de e-mails em sua conta.
 
 ## Deploy on Vercel
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -9,14 +9,17 @@ type CachedTransporter = {
 let cachedTransporterPromise: Promise<CachedTransporter> | null = null;
 
 async function createTransporter(): Promise<CachedTransporter> {
-  const senderEmail = getRequiredEnv("GMAIL_USER");
-  const appPassword = getRequiredEnv("GMAIL_APP_PASSWORD");
+  const smtpUser = getRequiredEnv("MAILERSEND_SMTP_USERNAME");
+  const smtpPassword = getRequiredEnv("MAILERSEND_SMTP_PASSWORD");
+  const senderEmail = getRequiredEnv("MAILERSEND_FROM_EMAIL");
 
   const transporter = nodemailer.createTransport({
-    service: "gmail",
+    host: "smtp.mailersend.net",
+    port: 587,
+    secure: false,
     auth: {
-      user: senderEmail,
-      pass: appPassword,
+      user: smtpUser,
+      pass: smtpPassword,
     },
   });
 


### PR DESCRIPTION
## Summary
- switch the email transporter to MailerSend's SMTP gateway
- document the new MailerSend environment variables and update the example env file

## Testing
- npm run build *(fails: Turbopack cannot download Google Fonts in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e71ef5178083328bec0c5759f09977