### PR TITLE
Add logout button to dashboard

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { requireUser } from "@/lib/auth";
 import { DashboardNavLink } from "@/components/dashboard/NavLink";
+import { LogoutButton } from "@/components/dashboard/LogoutButton";
 import { ReactNode } from "react";
 
 const navigation = [
@@ -29,13 +30,16 @@ export default async function DashboardLayout({
               <p className="text-xs text-slate-300">Olá, {user.name}</p>
             </div>
           </Link>
-          <nav className="flex items-center gap-3">
-            {navigation.map((item) => (
-              <DashboardNavLink key={item.href} href={item.href}>
-                {item.label}
-              </DashboardNavLink>
-            ))}
-          </nav>
+          <div className="flex items-center gap-4">
+            <nav className="flex items-center gap-3">
+              {navigation.map((item) => (
+                <DashboardNavLink key={item.href} href={item.href}>
+                  {item.label}
+                </DashboardNavLink>
+              ))}
+            </nav>
+            <LogoutButton />
+          </div>
         </div>
       </header>
       <main className="mx-auto flex w-full max-w-6xl flex-1 px-6 py-10">

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+import { SESSION_COOKIE_NAME } from "@/lib/auth";
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+    expires: new Date(0),
+  });
+
+  return response;
+}

--- a/src/components/dashboard/LogoutButton.tsx
+++ b/src/components/dashboard/LogoutButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/Button";
+
+async function logoutRequest(): Promise<void> {
+  const response = await fetch("/api/auth/logout", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Não foi possível encerrar a sessão.");
+  }
+}
+
+export function LogoutButton() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogout = async () => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      await logoutRequest();
+      router.replace("/");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Não foi possível encerrar a sessão.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-2 text-xs text-red-200/80">
+      <Button variant="ghost" onClick={handleLogout} disabled={isLoading}>
+        {isLoading ? "Saindo..." : "Sair"}
+      </Button>
+      {error ? <span className="text-[11px] text-red-300/80">{error}</span> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a logout API endpoint that clears the Sentinela session cookie
- add a client logout button to the dashboard header and wire it to the new endpoint
- update the dashboard layout to display the logout control alongside the navigation links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e723eeee7c833294ff7d6a72dde760