### PR TITLE
Enforce single daily check-in per day

### DIFF
--- a/src/app/api/check-ins/route.ts
+++ b/src/app/api/check-ins/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getUserFromRequest } from "@/lib/auth";
-import { insertCheckIn, listCheckInsByUser } from "@/lib/checkIns";
+import { listCheckInsByUser, saveCheckInForToday } from "@/lib/checkIns";
 
 function validatePayload(body: unknown) {
   if (!body || typeof body !== "object") {
@@ -42,15 +42,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Dados inválidos" }, { status: 400 });
   }
 
-  const entry = insertCheckIn({
-    userId: user.id,
-    date: new Date().toISOString(),
+  const result = saveCheckInForToday(user.id, {
     moodScore: payload.moodScore,
     stressScore: payload.stressScore,
     notes: payload.notes,
   });
 
-  return NextResponse.json({ checkIn: entry }, { status: 201 });
+  return NextResponse.json(
+    { checkIn: result.checkIn, updated: result.wasUpdated },
+    { status: result.wasUpdated ? 200 : 201 }
+  );
 }
 
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
## Summary
- add a unique database index and helper queries to locate check-ins for the current day
- update the API to upsert a single daily check-in instead of creating duplicates
- prefill the daily form with today’s saved data and signal when the submission is an update

## Testing
- npm run build *(fails: unable to download Google Fonts in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e7282fb3fc8332a500ab9cad0e74f9