### PR TITLE
feat: add check-in success toast on home

### DIFF
--- a/src/app/(dashboard)/daily-check-in/page.tsx
+++ b/src/app/(dashboard)/daily-check-in/page.tsx
@@ -54,13 +54,13 @@ async function submitCheckIn(formData: FormData) {
   }
 
   revalidatePath("/home");
-  redirect("/daily-check-in?success=1");
+  redirect("/home?checkInSuccess=1");
 }
 
 export default async function DailyCheckInPage({
   searchParams,
 }: {
-  searchParams: { success?: string; error?: string };
+  searchParams: { error?: string };
 }) {
   const user = await requireUser();
   const todaysCheckIn = getTodayCheckIn(user.id);
@@ -68,7 +68,6 @@ export default async function DailyCheckInPage({
   const defaultMood = todaysCheckIn?.moodScore ?? 3;
   const defaultStress = todaysCheckIn?.stressScore ?? 5;
   const defaultEnergy = parsedNotes.energyLevel ?? "Estável";
-  const showSuccess = searchParams?.success === "1";
   const showError = searchParams?.error === "1";
 
   return (
@@ -81,17 +80,12 @@ export default async function DailyCheckInPage({
         </p>
       </header>
 
-      {showSuccess && (
-        <div className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-200">
-          Check-in registrado. Obrigado por manter a rotina.
-        </div>
-      )}
       {showError && (
         <div className="rounded-2xl border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
           Não conseguimos salvar seu check-in. Tente novamente em instantes.
         </div>
       )}
-      {todaysCheckIn && !showSuccess && !showError && (
+      {todaysCheckIn && !showError && (
         <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
           Você já registrou seu check-in hoje. Ajuste os dados abaixo caso queira atualizar o relato.
         </div>
@@ -200,7 +194,7 @@ export default async function DailyCheckInPage({
 
         <button
           type="submit"
-          className="w-full rounded-2xl bg-gradient-to-r from-blue-900 to-amber-400 px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-amber-500/30 transition hover:shadow-amber-500/50"
+          className="w-full cursor-pointer rounded-2xl bg-gradient-to-r from-blue-900 to-amber-400 px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-amber-500/30 transition hover:shadow-amber-500/50"
         >
           {todaysCheckIn ? "Atualizar check-in" : "Enviar check-in"}
         </button>

--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -1,19 +1,28 @@
 import Link from "next/link";
 import { requireUser } from "@/lib/auth";
 import { getDashboardSummary } from "@/lib/checkIns";
+import { CheckInSuccessToast } from "@/components/check-in-success-toast";
 
 const formatter = new Intl.DateTimeFormat("pt-BR", {
   day: "2-digit",
   month: "short",
 });
 
-export default async function HomePage() {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams: { checkInSuccess?: string };
+}) {
   const user = await requireUser();
   const summary = getDashboardSummary(user.id);
   const latest = summary.latest;
+  const showCheckInToast = searchParams?.checkInSuccess === "1";
 
   return (
     <div className="space-y-8">
+      {showCheckInToast && (
+        <CheckInSuccessToast message="Obrigado por manter a rotina. Continue registrando diariamente para fortalecer a tropa." />
+      )}
       <section className="rounded-3xl border border-slate-800/70 bg-gradient-to-br from-slate-900/70 to-slate-950/90 p-8 shadow-xl shadow-blue-900/30">
         <h1 className="text-2xl font-semibold text-white">Bem-vindo de volta, {user.name.split(" ")[0]}!</h1>
         <p className="mt-2 max-w-2xl text-sm text-slate-300">
@@ -54,7 +63,7 @@ export default async function HomePage() {
           </p>
           <Link
             href="/daily-check-in"
-            className="mt-6 inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-blue-900 to-amber-400 px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-amber-500/30 transition hover:shadow-amber-500/50"
+            className="mt-6 inline-flex cursor-pointer items-center justify-center rounded-2xl bg-gradient-to-r from-blue-900 to-amber-400 px-5 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-amber-500/30 transition hover:shadow-amber-500/50"
           >
             Fazer check-in de hoje
           </Link>

--- a/src/components/check-in-success-toast.tsx
+++ b/src/components/check-in-success-toast.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+type CheckInSuccessToastProps = {
+  message: string;
+  duration?: number;
+};
+
+export function CheckInSuccessToast({ message, duration = 4000 }: CheckInSuccessToastProps) {
+  const [visible, setVisible] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setVisible(false);
+      router.replace("/home", { scroll: false });
+    }, duration);
+
+    return () => window.clearTimeout(timeout);
+  }, [duration, router]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center px-4">
+      <div className="pointer-events-auto flex w-full max-w-md items-start gap-3 rounded-2xl border border-emerald-400/40 bg-slate-950/90 px-4 py-3 text-sm text-emerald-100 shadow-xl shadow-emerald-500/20">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-500/20 text-lg font-semibold text-emerald-300">
+          ✓
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-emerald-100">Check-in registrado</p>
+          <p className="text-xs text-slate-300">{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- redirect the daily check-in submission to the home dashboard after successful saves
- display a dedicated toast on the home page confirming the check-in result
- add pointer cursor styling to the daily check-in entry points for clearer affordance

## Testing
- npm run build *(fails: next/font cannot download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e835625180833280340bd666c39ee1