### PR TITLE
Transform check-in success toast into modal dialog

### DIFF
--- a/src/components/check-in-success-toast.tsx
+++ b/src/components/check-in-success-toast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 
 type CheckInSuccessToastProps = {
@@ -21,22 +22,41 @@ export function CheckInSuccessToast({ message, duration = 4000 }: CheckInSuccess
     return () => window.clearTimeout(timeout);
   }, [duration, router]);
 
-  if (!visible) {
+  if (!visible || typeof document === "undefined") {
     return null;
   }
 
-  return (
-    <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center px-4">
-      <div className="pointer-events-auto flex w-full max-w-md items-start gap-3 rounded-2xl border border-emerald-400/40 bg-slate-950/90 px-4 py-3 text-sm text-emerald-100 shadow-xl shadow-emerald-500/20">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-500/20 text-lg font-semibold text-emerald-300">
-          ✓
+  return createPortal(
+    <div
+      role="alertdialog"
+      aria-live="assertive"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-10"
+      onClick={() => setVisible(false)}
+    >
+      <div
+        className="relative w-full max-w-md rounded-3xl border border-emerald-400/40 bg-slate-950/95 p-6 text-slate-100 shadow-2xl shadow-emerald-500/30"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-500/20 text-xl font-semibold text-emerald-300">
+            ✓
+          </div>
+          <div className="space-y-2 text-sm">
+            <h2 className="text-base font-semibold text-emerald-100">Check-in registrado</h2>
+            <p className="text-xs leading-relaxed text-slate-200">{message}</p>
+          </div>
         </div>
-        <div className="space-y-1">
-          <p className="text-sm font-semibold text-emerald-100">Check-in registrado</p>
-          <p className="text-xs text-slate-300">{message}</p>
-        </div>
+        <button
+          type="button"
+          onClick={() => setVisible(false)}
+          className="mt-6 inline-flex w-full items-center justify-center rounded-2xl bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-500/30"
+        >
+          Entendi
+        </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary
- render the check-in success feedback as a modal overlay with a backdrop via a React portal
- add dismiss controls and accessibility roles so the message behaves like a real notification dialog

## Testing
- npm run dev (fails to download Google Fonts in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e837182bd483328ecff9c230c343a9