### PR TITLE
Permitir edição de check-ins da última semana

### DIFF
--- a/src/app/api/check-ins/route.ts
+++ b/src/app/api/check-ins/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getUserFromRequest } from "@/lib/auth";
-import { listCheckInsByUser, saveCheckInForToday } from "@/lib/checkIns";
+import { listCheckInsByUser, saveCheckInForDate } from "@/lib/checkIns";
+
+function normalizeToUTCDate(date: Date) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
 
 function validatePayload(body: unknown) {
   if (!body || typeof body !== "object") {
@@ -12,7 +16,32 @@ function validatePayload(body: unknown) {
     moodScore?: number;
     stressScore?: number;
     notes?: string;
+    date?: unknown;
   };
+
+  let targetDate = new Date();
+  if ("date" in (body as Record<string, unknown>) && (body as Record<string, unknown>).date !== undefined) {
+    const rawDate = (body as { date?: unknown }).date;
+    if (typeof rawDate !== "string") {
+      return null;
+    }
+
+    const parsed = new Date(`${rawDate}T00:00:00.000Z`);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+
+    targetDate = parsed;
+  }
+
+  const normalizedTarget = normalizeToUTCDate(targetDate);
+  const today = normalizeToUTCDate(new Date());
+  const earliestAllowed = new Date(today);
+  earliestAllowed.setUTCDate(earliestAllowed.getUTCDate() - 7);
+
+  if (normalizedTarget < earliestAllowed || normalizedTarget > today) {
+    return null;
+  }
 
   if (
     typeof moodScore !== "number" ||
@@ -27,6 +56,7 @@ function validatePayload(body: unknown) {
     moodScore: Math.max(1, Math.min(5, Math.round(moodScore))),
     stressScore: Math.max(1, Math.min(10, Math.round(stressScore))),
     notes: notes && typeof notes === "string" ? notes : null,
+    date: normalizedTarget,
   };
 }
 
@@ -42,11 +72,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Dados inválidos" }, { status: 400 });
   }
 
-  const result = saveCheckInForToday(user.id, {
-    moodScore: payload.moodScore,
-    stressScore: payload.stressScore,
-    notes: payload.notes,
-  });
+  const result = saveCheckInForDate(
+    user.id,
+    payload.date,
+    {
+      moodScore: payload.moodScore,
+      stressScore: payload.stressScore,
+      notes: payload.notes,
+    }
+  );
 
   return NextResponse.json(
     { checkIn: result.checkIn, updated: result.wasUpdated },

--- a/src/components/daily-check-in-date-selector.tsx
+++ b/src/components/daily-check-in-date-selector.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+
+type Option = {
+  value: string;
+  label: string;
+};
+
+type DailyCheckInDateSelectorProps = {
+  options: Option[];
+  selected: string;
+};
+
+export function DailyCheckInDateSelector({
+  options,
+  selected,
+}: DailyCheckInDateSelectorProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <select
+      className="w-full rounded-2xl border border-slate-800/80 bg-slate-950/40 px-4 py-2 text-sm text-white focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400/40 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+      value={selected}
+      onChange={(event) => {
+        const newValue = event.target.value;
+        startTransition(() => {
+          const params = new URLSearchParams(searchParams.toString());
+          params.delete("error");
+          if (newValue) {
+            params.set("date", newValue);
+          } else {
+            params.delete("date");
+          }
+
+          const query = params.toString();
+          const url = query ? `/daily-check-in?${query}` : "/daily-check-in";
+          router.replace(url);
+        });
+      }}
+      disabled={isPending}
+      aria-label="Selecione a data do check-in"
+      aria-busy={isPending}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/lib/checkIns.ts
+++ b/src/lib/checkIns.ts
@@ -65,8 +65,11 @@ export function getDashboardSummary(userId: string): CheckInSummary {
   };
 }
 
-export function getTodayCheckIn(userId: string | number): CheckInRecord | undefined {
-  const bounds = getDayBounds(new Date());
+export function getCheckInForDate(
+  userId: string | number,
+  reference: Date
+): CheckInRecord | undefined {
+  const bounds = getDayBounds(reference);
 
   return findCheckInByUserAndDateRange(
     userId,
@@ -75,15 +78,20 @@ export function getTodayCheckIn(userId: string | number): CheckInRecord | undefi
   );
 }
 
-export function saveCheckInForToday(
+export function getTodayCheckIn(userId: string | number): CheckInRecord | undefined {
+  return getCheckInForDate(userId, new Date());
+}
+
+export function saveCheckInForDate(
   userId: string | number,
+  reference: Date,
   payload: {
     moodScore: number;
     stressScore: number;
     notes: string | null;
   }
 ): { checkIn: CheckInRecord; wasUpdated: boolean } {
-  const bounds = getDayBounds(new Date());
+  const bounds = getDayBounds(reference);
   const existing = findCheckInByUserAndDateRange(
     userId,
     bounds.start.toISOString(),
@@ -103,13 +111,24 @@ export function saveCheckInForToday(
 
   const entry = insertCheckIn({
     userId,
-    date: new Date().toISOString(),
+    date: bounds.start.toISOString(),
     moodScore: payload.moodScore,
     stressScore: payload.stressScore,
     notes: payload.notes,
   });
 
   return { checkIn: entry, wasUpdated: false };
+}
+
+export function saveCheckInForToday(
+  userId: string | number,
+  payload: {
+    moodScore: number;
+    stressScore: number;
+    notes: string | null;
+  }
+): { checkIn: CheckInRecord; wasUpdated: boolean } {
+  return saveCheckInForDate(userId, new Date(), payload);
 }
 
 export { listCheckInsByUser };


### PR DESCRIPTION
## Summary
- adiciona seletor de datas dos últimos sete dias na tela de check-in diário e reaproveita dados existentes para edição
- inclui a data do registro nas submissões e validação da API, aceitando somente dias até uma semana atrás
- ajusta a camada de persistência e cria um componente reutilizável para o seletor de datas

## Testing
- npm run build *(falha: bloqueio de download das fontes do Google Fonts no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68e83d4d9760833295da1b257401e8a5