### PR TITLE
Reset form values when switching check-in date

### DIFF
--- a/src/app/(dashboard)/daily-check-in/page.tsx
+++ b/src/app/(dashboard)/daily-check-in/page.tsx
@@ -141,7 +141,11 @@ export default async function DailyCheckInPage({
         </div>
       )}
 
-      <form action={submitCheckIn} className="space-y-8">
+      <form
+        key={activeDateOption.value}
+        action={submitCheckIn}
+        className="space-y-8"
+      >
         <input type="hidden" name="checkInDate" value={activeDateOption.value} />
         <section className="rounded-3xl border border-slate-800/70 bg-slate-900/70 p-6">
           <h2 className="text-lg font-semibold text-white">1. Como está o humor geral?</h2>


### PR DESCRIPTION
## Summary
- force the check-in form to remount whenever the selected date changes
- ensure the inputs show existing entries for that day or reset to defaults

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e874f7fc408332a6aafda7d0d9fba1