### PR TITLE
Improve dashboard header responsiveness on mobile

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
-import { requireUser } from "@/lib/auth";
+import { ReactNode } from "react";
+
 import { DashboardNavLink } from "@/components/dashboard/NavLink";
 import { LogoutButton } from "@/components/dashboard/LogoutButton";
 import { Logo } from "@/components/Logo";
-import { ReactNode } from "react";
+import { requireUser } from "@/lib/auth";
 
 const navigation = [
   { href: "/home", label: "Home" },
@@ -17,27 +18,30 @@ export default async function DashboardLayout({
   children: ReactNode;
 }) {
   const user = await requireUser();
+  const firstName = user.name.split(" ")[0] ?? user.name;
 
   return (
-    <div className="min-h-screen grid grid-rows-[auto_1fr] bg-slate-950/80">
+    <div className="grid min-h-screen grid-rows-[auto_1fr] bg-slate-950/80">
       <header className="border-b border-slate-800/80 bg-slate-900/70 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5 text-sm">
-          <Link href="/home" className="flex items-center gap-3">
-            <Logo size="sm" subtitle={`Olá, ${user.name}`} />
-          </Link>
-          <div className="flex items-center gap-4">
-            <nav className="flex items-center gap-3">
-              {navigation.map((item) => (
-                <DashboardNavLink key={item.href} href={item.href}>
-                  {item.label}
-                </DashboardNavLink>
-              ))}
-            </nav>
-            <LogoutButton />
+        <div className="mx-auto w-full max-w-6xl px-4 py-5 text-sm sm:px-6">
+          <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <Link href="/home" className="flex items-center gap-3">
+              <Logo size="sm" subtitle={`Olá, ${firstName}`} className="min-w-0" />
+            </Link>
+            <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+              <nav className="flex w-full items-center justify-start gap-2 overflow-x-auto rounded-2xl border border-slate-800/60 bg-slate-900/40 p-1 sm:w-auto sm:overflow-visible sm:rounded-none sm:border-none sm:bg-transparent sm:p-0">
+                {navigation.map((item) => (
+                  <DashboardNavLink key={item.href} href={item.href}>
+                    {item.label}
+                  </DashboardNavLink>
+                ))}
+              </nav>
+              <LogoutButton className="w-full sm:w-auto sm:items-end sm:self-end" />
+            </div>
           </div>
         </div>
       </header>
-      <main className="mx-auto flex w-full max-w-6xl flex-1 px-6 py-10">
+      <main className="mx-auto flex w-full max-w-6xl flex-1 px-4 py-8 sm:px-6 sm:py-10">
         <div className="w-full">{children}</div>
       </main>
     </div>

--- a/src/components/dashboard/LogoutButton.tsx
+++ b/src/components/dashboard/LogoutButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, type HTMLAttributes } from "react";
 
 import { Button } from "@/components/Button";
 
@@ -18,7 +18,11 @@ async function logoutRequest(): Promise<void> {
   }
 }
 
-export function LogoutButton() {
+type LogoutButtonProps = {
+  className?: string;
+} & HTMLAttributes<HTMLDivElement>;
+
+export function LogoutButton({ className, ...containerProps }: LogoutButtonProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -39,11 +43,21 @@ export function LogoutButton() {
   };
 
   return (
-    <div className="flex flex-col items-end gap-2 text-xs text-red-200/80">
-      <Button variant="ghost" onClick={handleLogout} disabled={isLoading}>
+    <div
+      className={`flex flex-col gap-2 text-xs text-red-200/80 ${className ?? ""}`}
+      {...containerProps}
+    >
+      <Button
+        variant="ghost"
+        onClick={handleLogout}
+        disabled={isLoading}
+        className="w-full justify-center sm:w-auto"
+      >
         {isLoading ? "Saindo..." : "Sair"}
       </Button>
-      {error ? <span className="text-[11px] text-red-300/80">{error}</span> : null}
+      {error ? (
+        <span className="text-[11px] text-red-300/80 sm:text-right">{error}</span>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- restructure the dashboard layout header to stack navigation and actions on narrow viewports and shorten the greeting
- allow the logout button to accept custom styling so it can stretch on mobile and align to the end on larger screens

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8756f93e883329f668804c891c490