### PR TITLE
Fix headers and cookies usage for Next.js 15

### DIFF
--- a/src/app/(dashboard)/daily-check-in/page.tsx
+++ b/src/app/(dashboard)/daily-check-in/page.tsx
@@ -57,7 +57,8 @@ async function submitCheckIn(formData: FormData) {
     date: normalizedDate,
   };
 
-  const origin = headers().get("origin") ?? process.env.APP_URL ?? "http://localhost:3000";
+  const headerList = await headers();
+  const origin = headerList.get("origin") ?? process.env.APP_URL ?? "http://localhost:3000";
   const cookieStore = await cookies();
   const cookieHeader = cookieStore
     .getAll()

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -63,7 +63,7 @@ function sessionToUser(session: SessionPayload | null): AuthenticatedUser | null
   };
 }
 
-function getUserFromHeaderBag(headerBag: Headers): AuthenticatedUser | null {
+function getUserFromHeaderBag(headerBag: { get(name: string): string | null }): AuthenticatedUser | null {
   const id = headerBag.get("x-user-id");
   const email = headerBag.get("x-user-email");
   const name = headerBag.get("x-user-name");
@@ -76,7 +76,7 @@ function getUserFromHeaderBag(headerBag: Headers): AuthenticatedUser | null {
 }
 
 async function getUserFromCookiesStore(): Promise<AuthenticatedUser | null> {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const sessionToken = cookieStore.get(SESSION_COOKIE_NAME)?.value;
 
   if (!sessionToken) {
@@ -103,7 +103,7 @@ export async function getUserFromRequest(request: NextRequest): Promise<Authenti
 }
 
 export async function requireUser(): Promise<AuthenticatedUser> {
-  const headerStore = headers();
+  const headerStore = await headers();
   const fromHeaders = getUserFromHeaderBag(headerStore);
 
   if (fromHeaders) {


### PR DESCRIPTION
## Summary
- await the Next.js headers helper before deriving the origin in the daily check-in action
- adjust auth utilities to await the cookies helper and accept any header bag with a get method

## Testing
- npm run build *(fails: Next.js Turbopack cannot download Google Fonts in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f057b60b5c8332aace8188b63faa4a