### PR TITLE
Handle missing metric arrays in analytics calculations

### DIFF
--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -32,13 +32,17 @@ type Alert = {
   message: string;
 };
 
-function average(values: number[]) {
-  if (!values.length) {
+function average(values: readonly number[] | null | undefined) {
+  const numericValues = Array.isArray(values)
+    ? values.filter((value): value is number => typeof value === "number")
+    : [];
+
+  if (numericValues.length === 0) {
     return null;
   }
 
-  const total = values.reduce((sum, value) => sum + value, 0);
-  return Math.round((total / values.length) * 10) / 10;
+  const total = numericValues.reduce((sum, value) => sum + value, 0);
+  return Math.round((total / numericValues.length) * 10) / 10;
 }
 
 function buildSeries(checkIns: ReturnType<typeof listCheckInsByUser>): NeuroMetricPoint[] {
@@ -81,9 +85,7 @@ function computeWeeklyAverages(series: NeuroMetricPoint[]) {
   };
 
   (Object.keys(result) as MetricKey[]).forEach((metric) => {
-    const values = recent
-      .map((item) => item[metric])
-      .filter((value): value is number => typeof value === "number");
+    const values = recent.map((item) => item[metric]);
     result[metric] = average(values);
   });
 

--- a/src/lib/checkIns.ts
+++ b/src/lib/checkIns.ts
@@ -20,10 +20,17 @@ export type CheckInSummary = {
   currentStreak: number;
 };
 
-function calculateAverage(values: number[]) {
-  if (!values.length) return null;
-  const total = values.reduce((acc, value) => acc + value, 0);
-  return Math.round((total / values.length) * 10) / 10;
+function calculateAverage(values: readonly number[] | null | undefined) {
+  const numericValues = Array.isArray(values)
+    ? values.filter((value): value is number => typeof value === "number")
+    : [];
+
+  if (numericValues.length === 0) {
+    return null;
+  }
+
+  const total = numericValues.reduce((acc, value) => acc + value, 0);
+  return Math.round((total / numericValues.length) * 10) / 10;
 }
 
 function computeStreak(checkIns: CheckInRecord[]) {


### PR DESCRIPTION
## Summary
- guard analytics average calculations against undefined or non-numeric metric arrays
- harden dashboard average helper to ignore unexpected input before reducing values

## Testing
- npm run build *(fails: next/font cannot download Google Fonts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f05fbce96883329a116f8f7af9c411